### PR TITLE
Feat approve orders

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -36,7 +36,6 @@ const corsOptions = {
   credentials: true,
 };
 
-
 // Middleware
 app.use(cors(corsOptions));
 app.use(bodyParser.json());

--- a/backend/app.js
+++ b/backend/app.js
@@ -79,7 +79,6 @@ app.use('*', (req, res) => {
 // Start server
 app.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`);
-  console.log(`CORS habilitado para: ${corsOptions.origin}`);
 });
 
 export default app;

--- a/backend/controllers/inventoryController.js
+++ b/backend/controllers/inventoryController.js
@@ -1,11 +1,13 @@
 // controllers/inventoryController.js
 
-import { 
-    getAllInventory,
-    getInventoryByStore,
-    assignInventoryToStore,
-    getWarehouseProducts
-  } from '../services/inventoryService.js';
+import {
+  getAllInventory,
+  getInventoryByStore,
+  assignInventoryToStore,
+  getWarehouseProducts,
+  editInventory,
+  getInventoryByStoreByProduct
+} from '../services/inventoryService.js';
   
   export const getInventory = async (req, res) => {
     try {
@@ -58,4 +60,33 @@ import {
     }
   };
   
-  
+export const updateInventory = async (req, res) => {
+  const { inventoryID, quantity } = req.body;
+  const employeeID = req.user?.employeeID;
+
+  if (!inventoryID || quantity == null || employeeID == null) {
+    return res.status(400).json({ message: 'inventoryID, quantity y employeeID son requeridos.' });
+  }
+
+  try {
+    const result = await editInventory(inventoryID, quantity, employeeID);
+    res.json(result);
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+export const getInventoryByStoreAndProduct = async (req, res) => {
+  const { storeID, productID } = req.query;
+
+  if (!storeID || !productID) {
+    return res.status(400).json({ message: 'storeID y productID son requeridos.' });
+  }
+
+  try {
+    const data = await getInventoryByStoreByProduct(storeID, productID);
+    res.json(data);
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+};

--- a/backend/controllers/orderController.js
+++ b/backend/controllers/orderController.js
@@ -65,14 +65,15 @@ export async function createOrder(req, res) {
   const { orderData, orderItems } = req.body;
   const employeeID = req.user?.employeeID;
   const storeID = req.user?.storeID;
+  const userRole = req.user?.role;
 
-  if (!employeeID || !storeID) {
-    return res.status(401).json({ error: 'Unauthorized: Missing employee or store ID from token' });
+  if (!employeeID || !storeID || !userRole) {
+    return res.status(401).json({ error: 'Unauthorized: Missing employee, store ID, or role from token' });
   }
 
   try {
-    const enrichedOrderData = { ...orderData, storeID }; // Override storeID from token
-    const result = await orderService.createOrder(enrichedOrderData, orderItems, employeeID);
+    const enrichedOrderData = { ...orderData, storeID }; // Force storeID from token
+    const result = await orderService.createOrder(enrichedOrderData, orderItems, employeeID, userRole);
     res.status(201).json(result);
   } catch (err) {
     res.status(500).json({ error: 'Failed to create order', details: err.message });
@@ -83,15 +84,23 @@ export async function updateOrder(req, res) {
   const { id } = req.params;
   const { updatedOrder, updatedItems } = req.body;
   const employeeID = req.user?.employeeID;
+  const userRole = req.user?.role; // Asegúrate de que el JWT o middleware proporcione esto
 
-  if (!employeeID) {
-    return res.status(401).json({ error: 'Unauthorized: Missing employee ID from token' });
+  if (!employeeID || !userRole) {
+    return res.status(401).json({ error: 'Unauthorized: Missing employee ID or role from token' });
   }
 
   try {
-    const result = await orderService.updateOrder(Number(id), updatedOrder, updatedItems, employeeID);
+    const result = await orderService.updateOrder(
+      Number(id),
+      updatedOrder,
+      updatedItems,
+      employeeID,
+      userRole
+    );
     res.json(result);
   } catch (err) {
     res.status(500).json({ error: 'Failed to update order', details: err.message });
   }
 }
+

--- a/backend/controllers/tableLogController.js
+++ b/backend/controllers/tableLogController.js
@@ -1,0 +1,46 @@
+// tableLogController.js
+
+import { getTableLogs, logToTableLogs } from '../services/tableLogService.js';
+
+/**
+ * GET /logs
+ * Query logs by tableName, employeeID, or recordID
+ */
+export async function getLogs(req, res) {
+  try {
+    const { tableName, employeeID, recordID } = req.query;
+
+    const logs = await getTableLogs({ tableName, employeeID, recordID });
+    res.json({ success: true, logs });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+}
+
+/**
+ * POST /logs
+ * Manually insert a new log entry
+ */
+export async function createLog(req, res) {
+  const { employeeID, tableName, recordID, action, comment = '' } = req.body;
+
+  if (!employeeID || !tableName || !recordID || !action) {
+    return res.status(400).json({
+      success: false,
+      message: 'Missing required fields: employeeID, tableName, recordID, action'
+    });
+  }
+
+  try {
+    await logToTableLogs({
+      employeeID,
+      tableName,
+      recordID,
+      action,
+      comment
+    });
+    res.status(201).json({ success: true, message: 'Log created successfully' });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+}

--- a/backend/routes/inventoryRoutes.js
+++ b/backend/routes/inventoryRoutes.js
@@ -6,7 +6,9 @@ import {
   getInventory,
   getStoreInventory,
   postInventory,
-  getWarehouseProductsController
+  getWarehouseProductsController,
+  updateInventory,
+  getInventoryByStoreAndProduct
 } from '../controllers/inventoryController.js';
 
 const router = express.Router();
@@ -15,5 +17,7 @@ router.get('/inventory/', verifyToken, getInventory); // ver todo lo que está e
 router.get('/inventory/store', verifyToken, getStoreInventory); // ver lo que está en el inventario de una tienda (depende de la JWT token, ahí cada quien tiene una tienda ID)
 router.get('/inventory/warehouse', verifyToken, getWarehouseProductsController); // ver productos disponibles en el almacén (storeid = 1)
 router.post('/inventory/', verifyToken, verifyRoles("admin", "manager", "warehouse_manager", "owner"), postInventory); // crear registro de cant. de productos en el inventario
+router.get('/inventory/by-sandp', verifyToken, getInventoryByStoreAndProduct); // Obtener un registro de inventario por tienda y producto
+router.put('/inventory/', verifyToken, verifyRoles("admin", "manager", "warehouse_manager", "owner"), updateInventory); // Editar cantidad de inventario existente
 
 export default router;

--- a/backend/routes/orderRoutes.js
+++ b/backend/routes/orderRoutes.js
@@ -14,12 +14,13 @@ import {
 
 const router = express.Router();
 
+// todos menos sales
 router.get('/orders', verifyToken, verifyRoles("admin", "owner", "manager", "warehouse_manager"), getAllOrders); // Get all orders
 router.get('/orders/active', verifyToken, verifyRoles("admin", "owner", "manager", "warehouse_manager"), getAllActiveOrders); // Get orders 'STATUS' != 'Cancelada' or 'Entregada' ["Pendiente", "Aprobada", "Confirmada", "Entregada", "Cancelada"]
 router.get('/orders/:id', verifyToken, verifyRoles("admin", "owner", "manager", "warehouse_manager"), getOrderById); // Get order by ID, este es importante porque muestra el detalle de la orden, orderitems, y orderhistory
 router.get('/orders/store/current', verifyToken, verifyRoles("admin", "owner", "manager", "warehouse_manager"), getOrdersByStore); // Ver las órdenes de la tienda actual (la tienda del usuario que está logueado, se obtiene del token JWT)
 router.get('/orders/employee/current', verifyToken, verifyRoles("admin", "owner", "manager", "warehouse_manager"), getOrdersByEmployee); // Ver las órdenes del empleado actual (el empleado del usuario que está logueado, se obtiene del token JWT)
-router.post('/orders', verifyToken, verifyRoles("admin", "owner", "manager", "warehouse_manager"), createOrder); // Crea una nueva order, se le asigna un ID automáticamente y se crea un registro en la base de datos
-router.put('/orders/:id', verifyToken, verifyRoles("admin", "owner", "manager", "warehouse_manager"), updateOrder); // actualizar una order (principalmente el status de la orden)
+router.post('/orders', verifyToken, verifyRoles("manager", "warehouse_manager"), createOrder); // Crea una nueva order, se le asigna un ID automáticamente y se crea un registro en la base de datos
+router.put('/orders/:id', verifyToken, verifyRoles("manager", "warehouse_manager"), updateOrder); // actualizar una order (principalmente el status de la orden)
 
 export default router;

--- a/backend/services/inventoryService.js
+++ b/backend/services/inventoryService.js
@@ -58,7 +58,7 @@ export const getWarehouseProducts = async () => {
   }
 };
 
-export const assignInventoryToStore = async (productID, storeID, quantity, employeeID = 0) => {
+export const assignInventoryToStore = async (productID, storeID, quantity, employeeID) => {
   const conn = await pool.acquire();
   try {
     // 1. Check if inventory record exists for product + store

--- a/backend/services/inventoryService.js
+++ b/backend/services/inventoryService.js
@@ -130,3 +130,50 @@ export const assignInventoryToStore = async (productID, storeID, quantity, emplo
     pool.release(conn);
   }
 };
+
+export const editInventory = async (inventoryID, quantity, employeeID) => {
+  const conn = await pool.acquire();
+  try {
+    // 1. Update the inventory record
+    const updateSql = `UPDATE WUSAP.Inventory SET quantity = ? WHERE inventoryID = ?`;
+    await new Promise((resolve, reject) => {
+      conn.prepare(updateSql, (err, stmt) => {
+        if (err) return reject(err);
+        stmt.exec([quantity, inventoryID], (err) => err ? reject(err) : resolve());
+      });
+    });
+
+    // 2. Log the action into TableLogs
+    const logSql = `
+      INSERT INTO WUSAP.TableLogs (employeeID, tableName, recordID, action)
+      VALUES (?, ?, ?, 'UPDATE')
+    `;
+    await new Promise((resolve, reject) => {
+      conn.prepare(logSql, (err, stmt) => {
+        if (err) return reject(err);
+        stmt.exec([employeeID, "Inventory", inventoryID], (err) =>
+          err ? reject(err) : resolve()
+        );
+      });
+    });
+
+    return { success: true, message: 'Inventario actualizado exitosamente' };
+  } finally {
+    pool.release(conn);
+  }
+}
+
+export const getInventoryByStoreByProduct = async (storeID, productID) => {
+  const conn = await pool.acquire();
+  try {
+    return await new Promise((resolve, reject) => {
+      conn.exec(
+        `SELECT * FROM WUSAP.Inventory WHERE storeID = ? AND productID = ?`,
+        [storeID, productID],
+        (err, result) => err ? reject(err) : resolve(result)
+      );
+    });
+  } finally {
+    pool.release(conn);
+  }
+}

--- a/backend/services/orderService.js
+++ b/backend/services/orderService.js
@@ -270,9 +270,9 @@ export async function updateOrder(orderID, updatedOrder, updatedItems, employeeI
     );
 
     const fieldMap = {
-      orderTotal: 'oldOrderTotal',
-      comments: 'oldComments',
-      status: 'oldStatus'
+      orderTotal: 'OLDORDERTOTAL',
+      comments: 'OLDCOMMENTS',
+      status: 'OLDSTATUS'
     };
 
     if (!orderData.length) throw new Error("Order not found");
@@ -341,16 +341,19 @@ export async function updateOrder(orderID, updatedOrder, updatedItems, employeeI
     );
 
     if (orderUpdateFields.length > 0) {
+      const logComment = `Updated order. ${orderUpdateFields.map(field => {
+        const fieldKey = fieldMap[field];
+        const oldVal = orderData[0][fieldKey];
+        const newVal = updatedOrder[field];
+        return `${field}: ${oldVal} → ${newVal}`;
+      }).join(' | ')}`;
+
       await logToTableLogs({
         employeeID,
         tableName: "Orders",
         recordID: orderID,
         action: "UPDATE",
-        comment: `Updated order. ${orderUpdateFields.map(field => {
-          const oldVal = orderData[0][fieldMap[field]];
-          const newVal = updatedOrder[field];
-          return `${field}: ${oldVal} → ${newVal}`;
-        }).join(' | ')}`
+        comment: logComment
       });
     }
 

--- a/backend/services/tableLogService.js
+++ b/backend/services/tableLogService.js
@@ -1,0 +1,66 @@
+// tableLogService.js
+
+import pool from '../db/hanaPool.js';
+
+/**
+ * Insert a new log entry into WUSAP.TableLogs.
+ * Now self-contained (acquires its own connection).
+ */
+export async function logToTableLogs({
+  employeeID,
+  tableName,
+  recordID,
+  action,
+  comment = ''
+}) {
+  const conn = await pool.acquire();
+  try {
+    if (!employeeID || isNaN(Number(employeeID))) {
+      console.error(`[logToTableLogs] Invalid employeeID:`, employeeID);
+      throw new Error("Missing or invalid employeeID for TableLogs");
+    }
+    if (!tableName || !recordID || !action) {
+      console.error(`[logToTableLogs] Missing required fields`, { tableName, recordID, action });
+      throw new Error("Missing tableName, recordID or action in TableLogs");
+    }
+
+    const sql = `
+      INSERT INTO WUSAP.TableLogs (employeeID, tableName, recordID, action, comment)
+      VALUES (?, ?, ?, ?, ?)
+    `;
+
+    await conn.exec(sql, [Number(employeeID), tableName, recordID, action, comment]);
+  } finally {
+    await pool.release(conn);
+  }
+}
+
+/**
+ * Fetch logs optionally filtered by tableName, employeeID, or recordID.
+ */
+export async function getTableLogs({ tableName, employeeID, recordID }) {
+  const conn = await pool.acquire();
+  try {
+    let query = `SELECT * FROM WUSAP.TableLogs WHERE 1=1`;
+    const params = [];
+
+    if (tableName) {
+      query += ` AND tableName = ?`;
+      params.push(tableName);
+    }
+    if (employeeID) {
+      query += ` AND employeeID = ?`;
+      params.push(employeeID);
+    }
+    if (recordID) {
+      query += ` AND recordID = ?`;
+      params.push(recordID);
+    }
+
+    query += ` ORDER BY timestamp DESC`;
+
+    return await conn.exec(query, params);
+  } finally {
+    await pool.release(conn);
+  }
+}


### PR DESCRIPTION
Integrar a main la función refactorizada de actualizar ordenes. Cuenta con las siguientes funcionalidades:

- wh_manager no puede actualizar orderitems de manager
- wh_manager no necesita dar “updatedItems” para actualizar estado
- Se resta de warehouse cuando se aprueba de una orden
- Manager sí puede actualizar sus items
- No se aprueba de una orden cuando no hay suficiente stock 
- Manager no puede auto aprobar orden
- se arregló error de comentarios (Undefined values en comment)
- Manager no puede modificar orden de wh_manager
- Funciona el check de no cambios al recibir orden ( a excepción de comentarios)
- Cuando no hay cambios en la llamada api se registra en los logs que no hubo cambios
- Checa que los orderItems pertenezcan a la orden
- Valida token y rol en la ruta
- Valida transiciones (Pendiente -> Aprobada, etc.)
- Cuando sólo se de 1 item, sí se actualiza sólo ese. 
- Bloquea actualización a Aprobado cuando no hay suficiente del item en almacén 
- Reembolsa inventario cuando se cancela orden (sólo cuando piden a warehouse)
- Agrega a inventario cuando llega orden
- Crea registro en inventario si no encuentra que esa tienda tenga ese producto